### PR TITLE
Replace transfer.sh with file.io in travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ script:
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -qmldir=./qml/ -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -qmldir=./qml/ -appimage
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
-  - curl --upload-file ./FeedTheMonkey*.AppImage https://transfer.sh/FeedTheMonkey-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+  - curl -F "file=@$(echo ./FeedTheMonkey*.AppImage) https://file.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ script:
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -qmldir=./qml/ -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -qmldir=./qml/ -appimage
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
-  - curl -F "file=@$(echo ./FeedTheMonkey*.AppImage) https://file.io
+  - curl -F "file=@$(echo FeedTheMonkey*.AppImage) https://file.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ script:
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -qmldir=./qml/ -bundle-non-qt-libs
   - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -qmldir=./qml/ -appimage
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
-  - curl -F "file=@$(echo FeedTheMonkey*.AppImage) https://file.io
+  - curl -F "file=@$(echo FeedTheMonkey*.AppImage)" https://file.io

--- a/qml/Content.qml
+++ b/qml/Content.qml
@@ -17,7 +17,7 @@
  * along with FeedTheMonkey.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtWebEngine 1.7
+import QtWebEngine 1.8
 import QtQuick 2.0
 import QtQuick.Controls 1.3
 import QtQuick.Layouts 1.1


### PR DESCRIPTION
transfer.sh is down so we need to find a new way of getting the image after it builds.